### PR TITLE
Added Delegate Callback whether Path is found

### DIFF
--- a/Assets/SAP2D/Core/Code/System/SAP2DAgent.cs
+++ b/Assets/SAP2D/Core/Code/System/SAP2DAgent.cs
@@ -98,6 +98,10 @@ namespace SAP2D {
             }
         }
 
+        // added a delegate we can subscribe to from anywhere
+        public delegate void PathIsFound(bool isFound);
+        public event PathIsFound ePathIsFound;
+
         private IEnumerator FindPath()
         { //path loop update
 
@@ -105,7 +109,14 @@ namespace SAP2D {
                 //if the object is already in the target point, the path should not be searched
                 if (grid.GetTileDataAtWorldPosition(transform.position).WorldPosition != grid.GetTileDataAtWorldPosition(Target.position).WorldPosition)
                 {
-                    path = pathfinder.FindPath(transform.position, Target.position, Config);
+                    //path = pathfinder.FindPath(transform.position, Target.position, Config);
+                    // we use the new definition for FindPath with path as out, and returning a bool whether or not the path is found.
+                    bool PathFound = pathfinder.FindPath(transform.position, Target.position, Config, out path);
+
+                    // If the Agent config says we should callback if a path was found or not
+                    if (Config.CallbackPathFound)
+                        ePathIsFound?.Invoke(PathFound);
+
                     pathIndex = 0;
                 }
             yield return new WaitForSeconds(PathUpdateRate);

--- a/Assets/SAP2D/Core/Code/System/SAP2DPathfinder.cs
+++ b/Assets/SAP2D/Core/Code/System/SAP2DPathfinder.cs
@@ -52,13 +52,29 @@ namespace SAP2D {
                 grid.CalculateColliders(startTile, endTile);
         }
 
+        // This definition exists to retain existing functionality
         public Vector2[] FindPath(Vector2 from, Vector2 to, SAP2DPathfindingConfig config)
+        {
+            bool PathFound;
+            return FindPathInternal(from, to, config, out PathFound);
+        }
+        // This definition exists so we can get a bool as to whether or not the path is found
+        public bool FindPath(Vector2 from, Vector2 to, SAP2DPathfindingConfig config, out Vector2[] path)
+        {
+            bool PathFound;
+            path = FindPathInternal(from, to, config, out PathFound);
+            return PathFound;
+        }
+
+        // Changed FindPath to FindPathInternal and added a bool as out to retain functionality, and to add bool functionality
+        private Vector2[] FindPathInternal(Vector2 from, Vector2 to, SAP2DPathfindingConfig config, out bool PathFound)
         {
             SAP_GridSource grid = GetGrid(config.GridIndex);
             SAP_TileData startTile = grid.GetTileDataAtWorldPosition(from);
             SAP_TileData targetTile = grid.GetTileDataAtWorldPosition(to);
             SAP_TileData currentTile = startTile;
 
+            PathFound = false;
             if (targetTile.isWalkable == false) return null;
 
             List<SAP_TileData> openList = new List<SAP_TileData>();
@@ -93,9 +109,14 @@ namespace SAP2D {
                 if (currentTile == null)
                 {
                     Debug.LogError("Path not found");
+
+                    // we return PathFound false here
+                    PathFound = false;
                     return null;
                 }
             }
+
+            PathFound = true;
             return PathRecovery(startTile, targetTile);
         }
 

--- a/Assets/SAP2D/Core/Code/System/SAP2DPathfindingConfig.cs
+++ b/Assets/SAP2D/Core/Code/System/SAP2DPathfindingConfig.cs
@@ -9,5 +9,6 @@ namespace SAP2D
     {
         public int GridIndex;
         public bool CutCorners;
+        public bool CallbackPathFound; // whether or not we want to trigger an event if the path cannot be found
     }
 }


### PR DESCRIPTION
Added a delegate so that it is possible to listen for the path becoming unavailable.   This can be useful for example: if you have a tower defence game and you do not want to be able to place a block if there is not a suitable path.

Also added an option in the agent config to turn this on or off.